### PR TITLE
Fix: Decrease the gap at top of site #4

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,6 +5,23 @@ from src.modules.energy_power_signals import run_energy_power_module
 from src.modules.signals import run_signals_module
 
 st.set_page_config(layout="wide", page_title="CS Viz", menu_items={})
+
+# Reduce top padding of the main container
+st.markdown(
+    """
+    <style>
+    .block-container {
+        padding-top: 2.5rem;
+        padding-bottom: 0rem;
+    }
+    header {
+        background-color: transparent !important;
+    }
+    </style>
+    """,
+    unsafe_allow_html=True,
+)
+
 st.sidebar.markdown("## Comm. Systems Visualizer")
 st.sidebar.markdown("---")
 


### PR DESCRIPTION
Added custom CSS to decrease the top padding of the main container. Fixes #4.

However the gap in the sidebar can't be reduced due to the default placement of the collapse sidebar button above the sidebar content.