### PR TITLE
Made Energy_power_singals.py robust, changed how energy and power signals are identified, added signal diagnostics subplots

### DIFF
--- a/src/core/signals.py
+++ b/src/core/signals.py
@@ -113,44 +113,90 @@ class Signal:
         # Support scalar * Signal
         return self.__mul__(other)
 
-    # ---------------- Energy & Power ----------------
     def energy(self, t):
         """
-        Discrete approximation of signal energy:
-        E = ∫ |x(t)|² dt
+        Approximate signal energy over a finite interval:
+        E ≈ ∫_{t_min}^{t_max} |x(t)|² dt
         """
         x = self.evaluate(t)
-        # Use robust trapezoidal integration (fallback if np.trapz unavailable)
-        return _trapz(np.abs(x) ** 2, t)
+
+        if len(t) < 2:
+            return 0.0
+
+        y = np.abs(x) ** 2
+
+        if np.any(np.isnan(y)) or np.any(np.isinf(y)):
+            return np.inf
+
+        return _trapz(y, t)
 
     def power(self, t):
         """
-        Discrete approximation of average power:
-        P = lim(T→∞) (1/2T) ∫ |x(t)|² dt
-        Approximated by time average.
+        Approximate average power over a finite interval:
+        P ≈ (1/T) ∫_{t_min}^{t_max} |x(t)|² dt
+
+        NOTE: True definition is as T → ∞
         """
         x = self.evaluate(t)
-        T = t[-1] - t[0]
-        if T == 0:
+
+        if len(t) < 2:
             return 0.0
-        return (1 / T) * _trapz(np.abs(x) ** 2, t)
+
+        T = t[-1] - t[0]
+        if T <= 0:
+            return 0.0
+
+        y = np.abs(x) ** 2
+
+        if np.any(np.isnan(y)) or np.any(np.isinf(y)):
+            return np.inf
+
+        return _trapz(y, t) / T
 
     def classify_signal(self, t):
-        E = self.energy(t)
+        """
+        Robust classification using convergence behavior.
+        """
 
-        P = self.power(t)
+        x = self.evaluate(t)
 
-        # Check if energy saturates (energy signal) vs grows linearly (power signal)
-        T = t[-1] - t[0]
-        if E < 1e3 and P < 1e-3:
-            return "Zero Signal", E, P
+        if len(t) < 2:
+            return "Undefined", 0.0, 0.0
 
-        # Estimate trend: if energy grows roughly linearly with T → power signal
-        dE_dt = E / T
-        if dE_dt > 0.1:
-            return "Power Signal", E, P
+        dt = t[1] - t[0]
+        N = len(x)
+
+        # Edge case: zero signal
+        if np.all(x == 0):
+            return "Zero Signal", 0.0, 0.0
+
+        # Progressive window sizes
+        splits = np.linspace(N // 5, N - 1, 5).astype(int)
+
+        energies = []
+        for s in splits:
+            E = np.sum(np.abs(x[:s]) ** 2) * dt
+            energies.append(E)
+
+        energies = np.array(energies)
+
+        # ---- Classification logic ----
+
+        # Case 1: Energy stabilizes → Energy Signal
+        if np.all(np.abs(np.diff(energies)) < 1e-2):
+            return "Energy Signal", energies[-1], 0.0
+
+        # Case 2: Energy keeps growing → Power Signal
+        elif np.all(np.diff(energies) > 0):
+            T = t[splits[-1]] - t[0]
+            P = energies[-1] / T if T > 0 else 0.0
+            return "Power Signal", np.inf, P
+
+        # Case 3: Neither
         else:
-            return "Energy Signal", E, P
+            T = t[-1] - t[0]
+            P = energies[-1] / T if T > 0 else 0.0
+            return "Neither", energies[-1], P
 
 
 # Signal Factory Functions

--- a/src/modules/energy_power_signals.py
+++ b/src/modules/energy_power_signals.py
@@ -8,10 +8,22 @@ from src.ui.plots import plot_signal
 from src.utils.time_axis import TimeAxis
 
 
+def safe_format(value):
+    # Format float values for display, handling edge cases like inf and NaN
+    if np.isinf(value):
+        return "∞"
+    if np.isnan(value):
+        return "Undefined"
+    return f"{value:.6f}"
+
+
 def run_energy_power_module():
     st.markdown("## ⚡ Energy & Power of Signals")
     st.text(
         "Understand energy signals, power signals, and why they matter in communication systems"
+    )
+    st.warning(
+        "Energy and Power are computed over a finite time interval and are approximations."
     )
 
     # Input Section
@@ -51,8 +63,54 @@ def run_energy_power_module():
     signal = build_signal_ui(signal_type)
     x = signal.evaluate(t)
 
+    # Guard against zero signal early to avoid misleading energy/power output
+    if np.all(x == 0):
+        st.info("Zero Signal detected")
+        return
+
+    if np.max(np.abs(x)) > 1e6:
+        st.warning("Signal amplitude too large, might cause numerical instability")
+
+    if len(t) > 1_000_000:
+        st.warning("Too many samples may lead to performance issues")
+
+    # Nyquist-based aliasing check — sampling should be at least 10x the signal's max frequency
+    if hasattr(signal, "max_frequency"):
+        if fs < 10 * signal.max_frequency():
+            st.warning("Sampling frequency may be too low and lead to aliasing")
+
+    # Sample interval derived from time axis, used for numerical integration
+    dt = t[1] - t[0]
+
+    # Trapezoidal cumulative integral — O(n), equivalent to trapz for uniform dt
+    energy_density = np.abs(x) ** 2
+    cumulative_energy = np.concatenate(
+        [[0], np.cumsum((energy_density[:-1] + energy_density[1:]) / 2 * dt)]
+    )
+
+    # Power convergence over symmetric intervals [-T, T] around t=0
+    # 300 points is sufficient for a smooth convergence curve
+    T_values = np.linspace(0.01, max(abs(t_min), abs(t_max)), 300)
+    power_vs_T = np.zeros_like(T_values)
+
+    # Subsample t and x for performance before the convergence loop
+    t_loop, x_loop = t, x
+    if len(t) > 100_000:
+        step = len(t) // 100_000
+        t_loop = t[::step]
+        x_loop = x[::step]
+
+    for i, T in enumerate(T_values):
+        # Create a symmetric mask around t=0
+        mask = (t_loop >= -T) & (t_loop <= T)
+        if mask.sum() < 2:
+            continue
+        # Integrate |x(t)|^2 over [-T, T] and normalize by 2T — matches the power formula
+        power_vs_T[i] = np.trapz(np.abs(x_loop[mask]) ** 2, t_loop[mask]) / (2 * T)
+
     # Energy & Power Computation
     # -------------------------------------------------
+    # Unpack classification result
     signal_type, E, P = signal.classify_signal(t)
 
     # Display Section
@@ -61,9 +119,9 @@ def run_energy_power_module():
     col_1, col_2, col_3 = st.columns([1, 1, 1])
 
     with col_1:
-        st.metric("Total Energy (E)", f"{E:.6f}")
+        st.metric("Total Energy (E)", safe_format(E))
     with col_2:
-        st.metric("Average Power (P)", f"{P:.6f}")
+        st.metric("Average Power (P)", safe_format(P))
     with col_3:
         st.info(signal_type)
 
@@ -81,10 +139,13 @@ def run_energy_power_module():
         st.plotly_chart(fig1, width="stretch", key="energy_power_signal")
 
     with col_right:
-        # Sliding window power (for visualization)
-        window_size = max(10, int(0.05 * len(x)))  # 5% window
-        power_time = np.convolve(
-            np.abs(x) ** 2, np.ones(window_size) / window_size, mode="same"
+        # Use a short sliding window to estimate instantaneous power for visualization
+        window_time = 0.1  # seconds
+        window_size = max(10, int(window_time * fs))  # ensure at least 10 samples
+
+        # Convolve with a box filter to get average power in each window
+        power_time = (
+            np.convolve(np.abs(x) ** 2, np.ones(window_size), mode="same") / window_size
         )
 
         # Power over time
@@ -96,6 +157,30 @@ def run_energy_power_module():
             autoscale=True,
         )
         st.plotly_chart(fig2, width="stretch", key="energy_power_plot")
+
+    st.subheader("Signal Diagnostics")
+    col3, col4 = st.columns(2)
+
+    with col3:
+        fig3 = plot_signal(
+            t,
+            cumulative_energy,
+            title="Cumulative Energy",
+            discrete=False,
+            autoscale=True,
+        )
+        st.plotly_chart(fig3, width="stretch", key="cumulative_energy_plot")
+
+    with col4:
+        # x-axis is T (window half-width), y-axis is power — shows convergence to P
+        fig4 = plot_signal(
+            T_values,
+            power_vs_T,
+            title="Power Convergence (symmetric around t=0)",
+            discrete=False,
+            autoscale=True,
+        )
+        st.plotly_chart(fig4, width="stretch", key="power_convergence_plot")
 
     # Educational Notes
     # -------------------------------------------------


### PR DESCRIPTION
For: #2 

## Changes

### Added
- `safe_format()` helper to handle edge cases (inf, NaN) in Energy and Power display
-  old code used raw f"{E:.6f}" which would crash on infinite energy/power signals
- Warning banner noting Energy and Power are finite-interval approximations
- Validation guards:
  - Zero signal detection to avoid misleading output
  - Amplitude overflow warning (> 1e6)
  - Sample count warning (> 1,000,000)
  - Nyquist aliasing check against signal's max frequency
- Signal Diagnostics section with two new subplots:
  - Cumulative Energy using vectorized trapezoidal cumsum:  O(n)
  - Power Convergence over symmetric [-T, T] intervals around t=0,
    with subsampling guard to prevent freezing at high sampling frequencies

### Changed
- Sliding window power: changed from a 5% signal-length window to a
  fixed 0.1s physical window (more meaningful across different signal lengths and fs)
  
  Please let me know if any changes are to be made